### PR TITLE
Fixed a relatively rare bug and a deprecation warning

### DIFF
--- a/amfm_decompy/pYAAPT.py
+++ b/amfm_decompy/pYAAPT.py
@@ -42,7 +42,7 @@ Version 1.0.7
 
 import numpy as np
 import numpy.lib.stride_tricks as stride_tricks
-from scipy.signal import firwin, hanning, kaiser, medfilt, lfilter
+from scipy.signal import firwin, hanning, kaiser, medfilt, lfilter, windows
 import scipy.interpolate as scipy_interp
 import amfm_decompy.basic_tools as basic
 
@@ -431,7 +431,7 @@ def nlfer(signal, pitch, parameters):
     N_f0_min = np.around((parameters['f0_min']*2/float(signal.new_fs))*pitch.nfft)
     N_f0_max = np.around((parameters['f0_max']/float(signal.new_fs))*pitch.nfft)
 
-    window = hanning(pitch.frame_size+2)[1:-1]
+    window = windows.hann(pitch.frame_size+2)[1:-1]
     data = np.zeros((signal.size))  #Needs other array, otherwise stride and
     data[:] = signal.filtered     #windowing will modify signal.filtered
 

--- a/amfm_decompy/pYAAPT.py
+++ b/amfm_decompy/pYAAPT.py
@@ -548,7 +548,7 @@ def spec_track(signal, pitch, parameters):
 
     else:
         if num_voiced_cand > 0:
-            voiced_pitch = (np.ones((1, num_voiced_cand)))*150.0
+            voiced_pitch = (np.ones((num_voiced_cand)))*150.0
         else:
             voiced_pitch = [150.0]
             cand_pitch[0, 0] = 0


### PR DESCRIPTION
Hi.

i was using your library in my project when i came across a small bug while debugging a numpy wrong arrays dimensions exception, so i found a fix for it and thankfully it worked, so i thought i might share it with you to get your thoughts on it.


here's a compressed version of the offending file for the bug


[GLF002591.zip](https://github.com/bjbschmitt/AMFM_decompy/files/2108770/GLF002591.zip)


as for the deprication warning it is caused when using the latest version of the scipy library as of date.
